### PR TITLE
DsQuickMenu itemSelected signal passes button position

### DIFF
--- a/Library/Dsqt/qml/waffles/DsQuickMenu.qml
+++ b/Library/Dsqt/qml/waffles/DsQuickMenu.qml
@@ -734,7 +734,7 @@ Item {
                 console.log("Selected segment "+seg);
                 root.state = "Off"
                 root.selection = 0
-                root.itemSelected(seg, Qt.point(0, 0)); // TODO: how to get button position from here?
+                root.itemSelected(seg, buttons.points[seg]);
                 break;
             }
         }

--- a/Library/Dsqt/qml/waffles/DsQuickMenu.qml
+++ b/Library/Dsqt/qml/waffles/DsQuickMenu.qml
@@ -23,7 +23,7 @@ Item {
     property bool fullyOpen: false
     property int closeTimer: appSettings.getInt("quickMenu.closeDelay") ?? 5000 //in ms, how long to wait before closing the menu after a click
     signal itemHighlighted(index: int, highlight: bool)
-    signal itemSelected(index: int)
+    signal itemSelected(index: int, position: point)
 
     state: "Off"
 
@@ -579,7 +579,13 @@ Item {
                     onTapped: {
                         root.state = "Off"
                         root.selection = 0
-                        root.itemSelected(button.index);
+                        root.itemSelected(
+                            button.index,
+                            {
+                                x: (root.x + button.x) - (root.width * 0.5),
+                                y: (root.y + button.y) - (root.height * 0.5),
+                            }
+                        );
                     }
                 }
             }
@@ -728,7 +734,7 @@ Item {
                 console.log("Selected segment "+seg);
                 root.state = "Off"
                 root.selection = 0
-                root.itemSelected(seg);
+                root.itemSelected(seg, Qt.point(0, 0)); // TODO: how to get button position from here?
                 break;
             }
         }
@@ -740,9 +746,6 @@ Item {
     DsClusterView.onUpdated: (point)=>{
         updatePoint(point);
     }
-
-
-
 
     //ClusterView.onUpdated: (point)=>{
     //    root.clusterPoint = point;

--- a/Library/Dsqt/qml/waffles/DsQuickMenu.qml
+++ b/Library/Dsqt/qml/waffles/DsQuickMenu.qml
@@ -576,15 +576,13 @@ Item {
                             root.itemHighlighted(button.index,false);
                         }
                     }
-                    onTapped: {
+                    onTapped: (eventPoint,eventButton)=> {
                         root.state = "Off"
                         root.selection = 0
+
                         root.itemSelected(
                             button.index,
-                            {
-                                x: (root.x + button.x) - (root.width * 0.5),
-                                y: (root.y + button.y) - (root.height * 0.5),
-                            }
+                            eventPoint.scenePosition
                         );
                     }
                 }
@@ -694,19 +692,6 @@ Item {
         }
     }
 
-
-
-    /*Rectangle {
-            id:tester_d
-            color: "blue"
-            opacity: 1.0
-            x: root.clusterPoint.x
-            y: root.clusterPoint.y
-            width: 20
-            height: 20
-        }
-    */
-
     Timer {
         id: closeTimer
         interval: root.closeTimer
@@ -734,7 +719,7 @@ Item {
                 console.log("Selected segment "+seg);
                 root.state = "Off"
                 root.selection = 0
-                root.itemSelected(seg, buttons.points[seg]);
+                root.itemSelected(seg, root.mapToGlobal(root.clusterPoint));
                 break;
             }
         }


### PR DESCRIPTION
Please note that I believe the "onReleased" emit-ing of this event is for the touch screen, which I am not able to test. This is the content of the second commit (e6b2dfa).

@afrancois can you pull this, bm/launcher on WhiteLableWaffles, and test using the touch screen? The Launcher should appear where you tap, with some general rough offset. That or communicate with me as to a touch device I can reasonably use in the office.