### PR TITLE
Update package-ecosystem to 'vcpkg' in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "vcpkg" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly" # Or weekly/monthly


### PR DESCRIPTION
While trying to build DsQt from the `ah/lean-and-mean` branch, I ran into an issue where my VCPKG was not up-to-date. AI recommended me to fix this by installing a Dependabot in the GitHub repo. While I am not 100% what it does, I would love to try this out.