### PR TITLE
Af/lean and mean thoughts

### DIFF
--- a/Library/DsQt/Bridge/bridge/dsQmlBridge.cpp
+++ b/Library/DsQt/Bridge/bridge/dsQmlBridge.cpp
@@ -10,6 +10,10 @@ DsQmlBridge::DsQmlBridge()
     // in a crash upon exit from a 'double free' error.
     QJSEngine::setObjectOwnership(this, QJSEngine::CppOwnership);
     m_content = model::ContentModel::createNamed("Bridge");
+    //connect database changed to bridge updated, since for now they are effectively the same thing.
+    //This is to provide a more specific signal that can be listened to on the main thread to know when Bridge
+    //has finished updating and all relevant properties have been updated.
+    connect(this, &DsQmlBridge::databaseChanged, this, &DsQmlBridge::bridgeUpdated);
 }
 
 model::ContentModel* DsQmlBridge::content() const {
@@ -26,6 +30,9 @@ void DsQmlBridge::setContent(model::ContentModel* newContent) {
     emit contentChanged();
 }
 
+//we are straying from the usual pattern of checking if we have the same database before setting it because we want to
+// make sure that any changes to the database are reflected in the UI.
+// If we check for the same database, then we might miss updates to the database that are made in place.
 void DsQmlBridge::setDatabase(DatabaseContent&& database) {
     m_database = std::move(database);
     emit databaseChanged();

--- a/Library/DsQt/Bridge/bridge/dsQmlBridge.h
+++ b/Library/DsQt/Bridge/bridge/dsQmlBridge.h
@@ -100,6 +100,13 @@ class DsQmlBridge : public QObject {
      */
     void databaseChanged();
 
+    /**
+     * @brief Emitted when the bridge has updated. In practice this is the same as databaseChanged, but with the
+     * semantic meaning that the update is complete and all relevant properties have been updated.
+     * You should listen to this on the main thread.
+     */
+    void bridgeUpdated();
+
   private:
     DsQmlBridge();
 

--- a/Library/DsQt/Bridge/model/dsQmlEventSchedule.cpp
+++ b/Library/DsQt/Bridge/model/dsQmlEventSchedule.cpp
@@ -53,6 +53,8 @@ QQmlListProperty<DsQmlEvent> DsQmlEventSchedule::timeline() {
 }
 
 
+/// Reads the current time from the clock (or system time as a fallback) and kicks off an
+/// asynchronous update.
 void DsQmlEventSchedule::updateNow() {
     if (m_clock)
         m_local_date_time = m_clock->now();
@@ -62,6 +64,8 @@ void DsQmlEventSchedule::updateNow() {
     update(m_local_date_time);
 }
 
+/// Called on the main thread when the background task completes. Diffs the new event lists
+/// against the current ones and emits eventsChanged only when something has changed.
 void DsQmlEventSchedule::onUpdated() {
     // This runs in the main thread when the background task completes.
     FutureResult result = m_watcher.result();
@@ -99,6 +103,9 @@ void DsQmlEventSchedule::onUpdated() {
     if (hasChanged) emit eventsChanged();
 }
 
+/// Performs the full filter → sort → timeline pipeline on a background thread.
+/// The result is handed back to the main thread via m_watcher / onUpdated().
+/// If a previous update is still running the call is dropped (see TODO in body).
 void DsQmlEventSchedule::update(const QDateTime& localDateTime) {
     if (m_watcher.isRunning()) return; // TODO handle this better.
 

--- a/Library/DsQt/Bridge/model/dsQmlEventSchedule.cpp
+++ b/Library/DsQt/Bridge/model/dsQmlEventSchedule.cpp
@@ -17,6 +17,14 @@ int DsQmlEvent::days() const {
     return m_record.value(DsQmlEventSchedule::EffectiveDays).toInt();
 }
 
+ContentModel *DsQmlEvent::model() const {
+    if(!m_model) {
+        QString modelUid = m_record.value("uid").toString();
+        m_model = bridge::DsQmlBridge::instance().getRecordById(modelUid);
+    }
+    return m_model;
+}
+
 DsQmlEventSchedule::DsQmlEventSchedule(QObject* parent)
     : DsQmlEventSchedule("", parent) {
 }
@@ -135,6 +143,8 @@ void DsQmlEventSchedule::update(const QDateTime& localDateTime) {
             for (const auto& event : std::as_const(events)) {
                 // No parent yet, as we're in a different thread.
                 DsQmlEvent* item = new DsQmlEvent(event, result.events.size(), nullptr);
+                if(bridge::isEventNow(item->record(),localDateTime)) item->setIsNow(true);
+
                 // Move to main thread.
                 item->moveToThread(mainThread);
                 // Add to result.
@@ -193,6 +203,19 @@ void DsQmlEventSchedule::update(const QDateTime& localDateTime) {
 
     // Set the future in the watcher to track completion.
     m_watcher.setFuture(future);
+}
+
+bool DsQmlEvent::isNow() const
+{
+    return m_isNow;
+}
+
+void DsQmlEvent::setIsNow(bool newIsNow)
+{
+    if (m_isNow == newIsNow)
+        return;
+    m_isNow = newIsNow;
+    emit isNowChanged();
 }
 
 } // namespace dsqt::model

--- a/Library/DsQt/Bridge/model/dsQmlEventSchedule.h
+++ b/Library/DsQt/Bridge/model/dsQmlEventSchedule.h
@@ -1,6 +1,74 @@
 #ifndef DSQMLEVENTSCHEDULE_H
 #define DSQMLEVENTSCHEDULE_H
 
+/**
+ * @file dsQmlEventSchedule.h
+ * @brief Event scheduling classes for QML integration.
+ *
+ * ## Overview
+ *
+ * This module provides two classes for exposing time-based scheduled events to QML:
+ *
+ * - **DsQmlEvent** — A read-only wrapper around a single scheduled event record from the
+ *   bridge database. Exposes start/end times, title, type, effective days, and display order.
+ *
+ * - **DsQmlEventSchedule** (QML: `DsEventSchedule`) — Queries the bridge database for events,
+ *   filters and sorts them, and exposes two views to QML:
+ *   - `events` — all matching events sorted by priority (highest priority first).
+ *   - `timeline` — a non-overlapping chronological timeline resolved from the priority-sorted
+ *     events. At any moment in time the highest-priority event wins, and consecutive slots
+ *     occupied by the same event are merged into a single entry.
+ *   - `current` — a convenience pointer to the highest-priority event that is active right now.
+ *
+ * ## How It Works
+ *
+ * `DsQmlEventSchedule` reacts to two signals:
+ *   1. **Clock ticks** — it connects to a `DsQmlClock` (a default internal clock is created
+ *      automatically). Every time the clock emits `secondsChanged` the schedule re-evaluates
+ *      which events are active.
+ *   2. **Database updates** — it also connects to `DsQmlBridge::databaseChanged` so the event
+ *      list is refreshed whenever the underlying data changes.
+ *
+ * The heavy lifting (database query, filtering, sorting, timeline construction) is performed on
+ * a background thread via `QtConcurrent::run`. The result is handed back to the main thread
+ * through a `QFutureWatcher`, which then updates the exposed lists and emits `eventsChanged`
+ * only when the data has actually changed.
+ *
+ * ## Timeline Algorithm
+ *
+ * 1. Retrieve all events for the current day from the bridge database.
+ * 2. Optionally filter to a single event type (see `DsQmlEventSchedule::type`).
+ * 3. Sort by priority relative to the current moment.
+ * 4. Collect all unique start/end times as *checkpoints*.
+ * 5. At each checkpoint, re-sort the events and record the winner (highest priority).
+ * 6. Truncate each slot so it ends when the next checkpoint begins.
+ * 7. Remove zero- or negative-duration slots.
+ * 8. Merge adjacent slots that resolve to the same event.
+ *
+ * ## QML Usage
+ *
+ * @code{.qml}
+ * import Dsqt
+ *
+ * DsEventSchedule {
+ *     id: schedule
+ *     type: "meeting"   // leave empty to include all event types
+ *
+ *     // Iterate over all priority-sorted events for today:
+ *     Repeater { model: schedule.events; delegate: MyEventDelegate {} }
+ *
+ *     // Or use the resolved, non-overlapping timeline:
+ *     Repeater { model: schedule.timeline; delegate: MyTimelineDelegate {} }
+ *
+ *     // Access the currently active event:
+ *     Text { text: schedule.current ? schedule.current.title : "No event" }
+ * }
+ * @endcode
+ *
+ * An external `DsQmlClock` can be supplied via the `clock` property to control (or mock) the
+ * current time, which is especially useful for testing or for "preview at time" features.
+ */
+
 #include "bridge/dsBridgeDatabase.h"
 #include "ui/dsQmlClock.h"
 
@@ -19,7 +87,16 @@
 // Q_DECLARE_LOGGING_CATEGORY(lgEventScheduleVerbose)
 namespace dsqt::model {
 
-// Wraps a scheduled event into a QML object.
+/**
+ * @brief A QML-accessible wrapper around a single scheduled event record.
+ *
+ * `DsQmlEvent` is created and owned by `DsQmlEventSchedule`; it should not be
+ * instantiated directly from QML (hence `QML_ANONYMOUS`).
+ *
+ * The `order` property reflects the event's position in the priority-sorted list produced
+ * by `DsQmlEventSchedule`. It can be used together with `color()` to assign a consistent
+ * color to each event across repeaters or delegates.
+ */
 class DsQmlEvent : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
@@ -108,7 +185,23 @@ class DsQmlEvent : public QObject {
     qsizetype              m_order;
 };
 
-// Provides a list of scheduled events, optionally filtered by type, and exposes it to QML.
+/**
+ * @brief Queries scheduled events from the bridge database and exposes them to QML.
+ *
+ * Registered in QML as `DsEventSchedule`.
+ *
+ * The schedule listens for two update triggers:
+ *  - **Clock ticks**: via a connected `DsQmlClock`. A default internal clock is created
+ *    automatically; supply an external one via the `clock` property to control or mock time.
+ *  - **Database changes**: via `DsQmlBridge::databaseChanged`.
+ *
+ * On each update the schedule runs a background pipeline that filters, sorts, and resolves
+ * the day's events, then notifies QML through `eventsChanged` only when the result differs
+ * from the previous state.
+ *
+ * @note All three list properties (`events`, `timeline`, `current`) share a single
+ *       `eventsChanged` notification signal.
+ */
 class DsQmlEventSchedule : public QObject {
     Q_OBJECT
     QML_NAMED_ELEMENT(DsEventSchedule)
@@ -119,35 +212,40 @@ class DsQmlEventSchedule : public QObject {
     Q_PROPERTY(dsqt::ui::DsQmlClock* clock READ clock WRITE setClock NOTIFY clockChanged)
 
   public:
+    /// Database column name for an event's start date/time.
     inline static const char* StartDateTime = "start_date_time";
+    /// Database column name for an event's end date/time.
     inline static const char* EndDateTime   = "end_date_time";
+    /// Database column name for the bitmask of days on which an event is effective.
     inline static const char* EffectiveDays = "effective_days";
 
     explicit DsQmlEventSchedule(QObject* parent = nullptr);
     DsQmlEventSchedule(const QString& type_name, QObject* parent = nullptr);
     ~DsQmlEventSchedule();
 
-    // Returns the event type, or an empty string if not set.
+    /// Returns the event type filter, or an empty string if all types are included.
     const QString& type() const { return m_type_name; }
-    // Sets the event type, causing events to be filtered if not empty.
+    /// Sets the event type filter. When non-empty only events of this type are returned.
     void setType(const QString& type) {
         if (type == m_type_name) return;
         m_type_name = type;
         emit typeChanged();
     }
 
-    // Returns all events, sorted from highest to lowest priority.
+    /// Returns all matching events for the current day, sorted from highest to lowest priority.
     QQmlListProperty<DsQmlEvent> events();
-    // Returns all events as a timeline, with all overlapping events resolved to a single event.
+    /// Returns a non-overlapping chronological timeline. Overlapping slots are resolved to the
+    /// highest-priority event; adjacent slots for the same event are merged.
     QQmlListProperty<DsQmlEvent> timeline();
-    // Returns the currently active event, or nullptr if no event is active.
+    /// Returns the highest-priority event that is currently active right now, or nullptr if none.
     DsQmlEvent* current() const {
         if (m_events.isEmpty()) return nullptr;
         return m_events.front();
     }
-    //
+    /// Returns the clock used to determine the current time.
     ui::DsQmlClock* clock() const { return m_clock; }
-    //
+    /// Sets the clock used to determine the current time. An internal default clock is used
+    /// when no external clock is supplied.
     void setClock(ui::DsQmlClock* clock) {
         if (m_clock == clock) return;
 

--- a/Library/DsQt/Bridge/model/dsQmlEventSchedule.h
+++ b/Library/DsQt/Bridge/model/dsQmlEventSchedule.h
@@ -71,6 +71,7 @@
 
 #include "bridge/dsBridgeDatabase.h"
 #include "ui/dsQmlClock.h"
+#include "model/dsContentModel.h"
 
 #include <QColor>
 #include <QDateTime>
@@ -109,7 +110,8 @@ class DsQmlEvent : public QObject {
     Q_PROPERTY(qsizetype order READ order WRITE setOrder NOTIFY orderChanged)
     Q_PROPERTY(double secondsSinceMidnight READ secondsSinceMidnight CONSTANT)
     Q_PROPERTY(double durationInSeconds READ durationInSeconds CONSTANT)
-
+    Q_PROPERTY(dsqt::model::ContentModel* model READ model FINAL)
+    Q_PROPERTY(bool isNow READ isNow WRITE setIsNow NOTIFY isNowChanged FINAL)
   public:
     explicit DsQmlEvent(QObject* parent = nullptr)
         : QObject(parent) {}
@@ -144,6 +146,7 @@ class DsQmlEvent : public QObject {
     }
 
     int days() const;
+    ContentModel* model() const;
 
     qsizetype order() const { return m_order; }
     void      setOrder(qsizetype order) {
@@ -167,9 +170,12 @@ class DsQmlEvent : public QObject {
 
     bool operator==(const DsQmlEvent& rhs) const {
         // Do not compare titles.
-        return (m_order == rhs.m_order && m_start == rhs.m_start && m_end == rhs.m_end && uid() == rhs.uid());
+        return (m_order == rhs.m_order && m_start == rhs.m_start && m_end == rhs.m_end && m_isNow == rhs.m_isNow && uid() == rhs.uid());
     }
     bool operator!=(const DsQmlEvent& rhs) const { return !(*this == rhs); }
+
+    bool isNow() const;
+    void setIsNow(bool newIsNow);
 
   signals:
     void titleChanged();
@@ -177,12 +183,16 @@ class DsQmlEvent : public QObject {
     void endChanged();
     void orderChanged();
 
+    void isNowChanged();
+
   private:
     bridge::DatabaseRecord m_record;
     QString                m_title;
     QDateTime              m_start;
     QDateTime              m_end;
     qsizetype              m_order;
+    mutable dsqt::model::ContentModel *m_model = nullptr;
+    bool m_isNow=false;
 };
 
 /**
@@ -237,11 +247,13 @@ class DsQmlEventSchedule : public QObject {
     /// Returns a non-overlapping chronological timeline. Overlapping slots are resolved to the
     /// highest-priority event; adjacent slots for the same event are merged.
     QQmlListProperty<DsQmlEvent> timeline();
+
     /// Returns the highest-priority event that is currently active right now, or nullptr if none.
     DsQmlEvent* current() const {
-        if (m_events.isEmpty()) return nullptr;
+        if (m_events.isEmpty() || !m_events.front()->isNow()) return nullptr;
         return m_events.front();
     }
+
     /// Returns the clock used to determine the current time.
     ui::DsQmlClock* clock() const { return m_clock; }
     /// Sets the clock used to determine the current time. An internal default clock is used


### PR DESCRIPTION
There are a few changes:

- Reintroduction of Bridgechanged signal. see comments for explanation.
- Comments in the DsQmlEventSchedule. not understanding this class was problematic. @paulhoux  can you review this specifically?
- Added the ability to get the DsContentModel for the UID associated with DsQmlEvent via .current.model. This might be better as directly as .model as DsQmlEvent might be intended as an internal class?
- Added marking DsQmlEvents as happening right now and only return current if this flag is true. This fixes a bug where if there were events today, but none were actually happening it would still return one of the events. 
