### PR TITLE
Mark DsSpoutReceiverView node dirty so ShaderEffectSource updates

### DIFF
--- a/Library/DsQt/Spout/src/dsQmlSpoutReceiverView.cpp
+++ b/Library/DsQt/Spout/src/dsQmlSpoutReceiverView.cpp
@@ -168,5 +168,6 @@ QSGNode* DsQmlSpoutReceiverView::updatePaintNode(QSGNode* oldNode, UpdatePaintNo
 
     node->setTexture(rhiTexture, senderSize);
     node->setRect(boundingRect());
+    node->markDirty(QSGNode::DirtyMaterial);
     return node;
 }


### PR DESCRIPTION
DsSpoutReceiverView wasn't marking its scene graph node dirty after each texture swap, so ShaderEffectSource never picked up new frames. Adding markDirty(QSGNode::DirtyMaterial) in updatePaintNode fixes this.