### PR TITLE
Spout cmake: Make shaders name unique

### DIFF
--- a/Library/DsQt/Spout/CMakeLists.txt
+++ b/Library/DsQt/Spout/CMakeLists.txt
@@ -86,7 +86,7 @@ qt_add_qml_module(DsSpout
     DEPENDENCIES QtQuick
 )
 
-qt6_add_shaders(DsSpout "shaders"
+qt6_add_shaders(DsSpout "dsqt_spout_shaders"
     PREFIX "/"
     HLSL 50
     PRECOMPILE


### PR DESCRIPTION
Apparently if you use qt_add_shaders() in a library, the name you pick can conflict with an applications use of qt_add_shaders() if they're the same. This makes the spout shaders name more unique to avoid this issue.