### PR TITLE
Fix linker error for Spout shaders

### DIFF
--- a/Library/DsQt/Spout/src/dsSpoutMaterial.cpp
+++ b/Library/DsQt/Spout/src/dsSpoutMaterial.cpp
@@ -53,7 +53,7 @@ void DsSpoutMaterial::setMipmapFiltering(QSGTexture::Filtering filtering)
 DsSpoutMaterialShader::DsSpoutMaterialShader()
 {
     // Ensure shader resources are initialized (needed for static library linking)
-    Q_INIT_RESOURCE(shaders);
+    Q_INIT_RESOURCE(dsqt_spout_shaders);
 
     setShaderFileName(VertexStage,
                       QStringLiteral(":/resources/shaders/texture.vert.qsb"));


### PR DESCRIPTION
Fix compile issue when building apps that use Spout.  Needed to also rename the shader resources name in the cpp's Q_INIT_RESOURCE macro invocation