### PR TITLE
Af/fix spout lib install

### DIFF
--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -61,9 +61,9 @@ endif()
 
 find_package(Qt6 6.9
     REQUIRED COMPONENTS
-        Core 
+        Core
         Concurrent
-        Gui 
+        Gui
         Qml
         Quick
 )
@@ -216,10 +216,11 @@ if(PROJECT_IS_TOP_LEVEL)
     # Spout module (Windows only)
     if(WIN32 AND TARGET DsSpout)
         set(_spout_install_targets DsSpout DsSpoutplugin)
-        if(TARGET SpoutDX_static)
-            # FetchContent build — install the in-tree static lib too
-            list(APPEND _spout_install_targets SpoutDX_static)
-        endif()
+
+        #if(TARGET SpoutDX_static)
+            # FetchContent build — install the in-tree #static lib too
+            #list(APPEND _spout_install_targets #SpoutDX_static)
+        #endif()
         install(TARGETS ${_spout_install_targets}
             LIBRARY    DESTINATION ${CMAKE_INSTALL_LIBDIR}/$<CONFIG>
             ARCHIVE    DESTINATION ${CMAKE_INSTALL_LIBDIR}/$<CONFIG>

--- a/Library/DsQt/Spout/CMakeLists.txt
+++ b/Library/DsQt/Spout/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Spout2 QUIET)
 if(Spout2_FOUND)
     message(STATUS "DsQt/Spout: Using installed Spout2 ${Spout2_VERSION}")
     set(_spout_dx_target Spout2::SpoutDX_static)
+    set(Spout2_Static "true")
 else()
     message(STATUS "DsQt/Spout: Spout2 not found locally — fetching from GitHub")
     include(FetchContent)
@@ -149,3 +150,8 @@ install(DIRECTORY .
         PATTERN "*.h"
         PATTERN "*.hpp"
 )
+if(Spout2_Static)
+    install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/SpoutDX_static.lib"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/$<CONFIG>
+            )
+endif()

--- a/Library/DsQt/Spout/CMakeLists.txt
+++ b/Library/DsQt/Spout/CMakeLists.txt
@@ -151,7 +151,9 @@ install(DIRECTORY .
         PATTERN "*.hpp"
 )
 if(Spout2_Static)
-    install(FILES "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/SpoutDX_static.lib"
+    install(FILES
+        "$<$<CONFIG:Debug>:${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/SpoutDX_static.lib>"
+        "$<$<NOT:$<CONFIG:Debug>>:${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/SpoutDX_static.lib>"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/$<CONFIG>
             )
 endif()


### PR DESCRIPTION
SpoutDX_static.lib was not being installed with change to using vcpkg for spout. This fixes that.