### PR TITLE
Do not continuously update the Spout receiver…

### DIFF
--- a/Library/DsQt/Spout/src/dsQmlSpoutReceiverView.cpp
+++ b/Library/DsQt/Spout/src/dsQmlSpoutReceiverView.cpp
@@ -64,17 +64,17 @@ void DsQmlSpoutReceiverView::connectReceiver()
         update();
     });
 
-    // Continuous rendering — request update after each frame is presented
-    if (window()) {
-        connect(window(), &QQuickWindow::frameSwapped,
-                this, &QQuickItem::update, Qt::QueuedConnection);
-    }
-    connect(this, &QQuickItem::windowChanged, this, [this](QQuickWindow* win) {
-        if (win) {
-            connect(win, &QQuickWindow::frameSwapped,
-                    this, &QQuickItem::update, Qt::QueuedConnection);
-        }
-    });
+    // // Continuous rendering — request update after each frame is presented
+    // if (window()) {
+    //     connect(window(), &QQuickWindow::frameSwapped,
+    //             this, &QQuickItem::update, Qt::QueuedConnection);
+    // }
+    // connect(this, &QQuickItem::windowChanged, this, [this](QQuickWindow* win) {
+    //     if (win) {
+    //         connect(win, &QQuickWindow::frameSwapped,
+    //                 this, &QQuickItem::update, Qt::QueuedConnection);
+    //     }
+    // });
 }
 
 void DsQmlSpoutReceiverView::disconnectReceiver()


### PR DESCRIPTION
…only update on frame received. This helps to keep the frame rate as low as possible, which is a good thing.