### PR TITLE
This allows us to keep our application window as the front-most...

### DIFF
--- a/Library/DsQt/Core/CMakeLists.txt
+++ b/Library/DsQt/Core/CMakeLists.txt
@@ -119,7 +119,7 @@ target_link_libraries(Core PUBLIC
     Qt6::Gui 
     Qt6::Qml 
     Coreplugin
-    user32 # For WindowHelper
+    $<$<PLATFORM_ID:Windows>:user32> # For WindowHelper
 )
 
 target_include_directories(Core

--- a/Library/DsQt/Core/CMakeLists.txt
+++ b/Library/DsQt/Core/CMakeLists.txt
@@ -98,6 +98,7 @@ qt_add_qml_module(Core
         utility/dsFileMetaData.cpp utility/dsFileMetaData.h
         utility/dsStringUtils.cpp utility/dsStringUtils.h
         utility/dsUrlImageLoader.cpp utility/dsUrlImageLoader.h
+        utility/WindowHelper.h
 
     #DEPENDENCIES
     #     QtQuick
@@ -118,6 +119,7 @@ target_link_libraries(Core PUBLIC
     Qt6::Gui 
     Qt6::Qml 
     Coreplugin
+    user32 # For WindowHelper
 )
 
 target_include_directories(Core

--- a/Library/DsQt/Core/qml/DsAppBase.qml
+++ b/Library/DsQt/Core/qml/DsAppBase.qml
@@ -27,7 +27,7 @@ ApplicationWindow {
     Timer {
         id: refocusTimer
         interval: windowProxy.getInt("forceToFrontInterval", 2000)
-        repeat: false
+        repeat: true
         onTriggered: if(windowProxy.getBool("forceToFront",false)) WindowHelper.forceToFront(window)
     }
 

--- a/Library/DsQt/Core/qml/DsAppBase.qml
+++ b/Library/DsQt/Core/qml/DsAppBase.qml
@@ -20,7 +20,11 @@ ApplicationWindow {
             refocusTimer.stop()
         } else {
             console.log("Window is no longer front-most")
-            refocusTimer.start()
+            if(windowProxy.getBool("forceToFront",false) && windowProxy.getString("mode","window") !== "window") {
+                refocusTimer.start()
+            } else {
+                refocusTimer.stop()
+            }
         }
     }
 
@@ -28,7 +32,7 @@ ApplicationWindow {
         id: refocusTimer
         interval: windowProxy.getInt("forceToFrontInterval", 2000)
         repeat: true
-        onTriggered: if(windowProxy.getBool("forceToFront",false)) WindowHelper.forceToFront(window)
+        onTriggered: indowHelper.forceToFront(window)
     }
 
     // Keep track of screen changes.

--- a/Library/DsQt/Core/qml/DsAppBase.qml
+++ b/Library/DsQt/Core/qml/DsAppBase.qml
@@ -13,6 +13,24 @@ ApplicationWindow {
     visible: false // Will become visible once setup.
     color: "black"
 
+    // Keep track of active changes.
+    onActiveChanged: {
+        if (active) {
+            console.log("Window is now front-most / active")
+            refocusTimer.stop()
+        } else {
+            console.log("Window is no longer front-most")
+            refocusTimer.start()
+        }
+    }
+
+    Timer {
+        id: refocusTimer
+        interval: windowProxy.getInt("forceToFrontInterval", 2000)
+        repeat: false
+        onTriggered: if(windowProxy.getBool("forceToFront",false)) WindowHelper.forceToFront(window)
+    }
+
     // Keep track of screen changes.
     onScreenChanged: {
         var screens = Application.screens
@@ -193,36 +211,36 @@ ApplicationWindow {
 
         property DsTextFileViewer appLogWindow: null
         onLogsApplicationTriggered: (isChecked) => {
-                                        if(appLogWindow === null) {
-                                            appLogWindow = appLog.createObject(window)
-                                            appLogWindow.closing.connect( () => { windowMenuBar.logsApplicationChecked = false } )
-                                        }
-                                        appLogWindow.file = ""
-                                        appLogWindow.file = Ds.env.logFile();
-                                        appLogWindow.visible = isChecked
-                                    }
+            if(appLogWindow === null) {
+                appLogWindow = appLog.createObject(window)
+                appLogWindow.closing.connect( () => { windowMenuBar.logsApplicationChecked = false } )
+            }
+            appLogWindow.file = ""
+            appLogWindow.file = Ds.env.logFile();
+            appLogWindow.visible = isChecked
+        }
 
         property DsTextFileViewer bridgeSyncLogWindow: null
         onLogsBridgeSyncTriggered: (isChecked) => {
-                                       if(bridgeSyncLogWindow === null) {
-                                           bridgeSyncLogWindow = bridgeSyncLog.createObject(window)
-                                           bridgeSyncLogWindow.closing.connect( () => { windowMenuBar.logsBridgeSyncChecked = false } )
-                                       }
-                                       bridgeSyncLogWindow.visible = isChecked
-                                   }
+            if(bridgeSyncLogWindow === null) {
+                bridgeSyncLogWindow = bridgeSyncLog.createObject(window)
+                bridgeSyncLogWindow.closing.connect( () => { windowMenuBar.logsBridgeSyncChecked = false } )
+            }
+            bridgeSyncLogWindow.visible = isChecked
+        }
 
         property var contentBrowser: null
         onContentBrowseToggled: (isChecked) => {
-                                    if (window.contentViewerComponent === null) {
-                                        console.warn("Content browser not available")
-                                        return
-                                    }
-                                    if(contentBrowser === null) {
-                                        contentBrowser = window.contentViewerComponent.createObject(window)
-                                        contentBrowser.closing.connect( () => { windowMenuBar.contentBrowseChecked = false } )
-                                    }
-                                    contentBrowser.visible = isChecked
-                                }
+            if (window.contentViewerComponent === null) {
+                console.warn("Content browser not available")
+                return
+            }
+            if(contentBrowser === null) {
+                contentBrowser = window.contentViewerComponent.createObject(window)
+                contentBrowser.closing.connect( () => { windowMenuBar.contentBrowseChecked = false } )
+            }
+            contentBrowser.visible = isChecked
+        }
 
         property DsSettingsViewer settingsEngineWindow: null
         onSettingsEngineTriggered: {

--- a/Library/DsQt/Core/utility/WindowHelper.h
+++ b/Library/DsQt/Core/utility/WindowHelper.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QObject>
+#include <QQuickWindow>
+#include <QQmlEngine>
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
+class WindowHelper : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON  // Optional: makes it a singleton so you don't need to instantiate it in QML
+
+public:
+    explicit WindowHelper(QObject *parent = nullptr) : QObject(parent) {}
+
+    Q_INVOKABLE void forceToFront(QQuickWindow *window)
+    {
+#ifdef Q_OS_WIN
+        HWND hwnd = reinterpret_cast<HWND>(window->winId());
+        DWORD fgThread = GetWindowThreadProcessId(GetForegroundWindow(), nullptr);
+        DWORD appThread = GetCurrentThreadId();
+
+        if (fgThread != appThread) {
+            AttachThreadInput(fgThread, appThread, TRUE);
+            BringWindowToTop(hwnd);
+            SetForegroundWindow(hwnd);
+            AttachThreadInput(fgThread, appThread, FALSE);
+        } else {
+            BringWindowToTop(hwnd);
+            SetForegroundWindow(hwnd);
+        }
+#else
+        window->raise();
+        window->requestActivate();
+#endif
+    }
+};


### PR DESCRIPTION
...which is necessary when running TouchDesigner content in the background. Use the `forceToFront = true` setting under `[engine.window]` to enable this functionality. Optionally, use `forceToFrontInterval' (defaults to 2000) to set the timeout interval.