### PR TITLE
Revert "Make the more robust private-reinject the default."

### DIFF
--- a/Library/DsQt/Touch/CMakeLists.txt
+++ b/Library/DsQt/Touch/CMakeLists.txt
@@ -3,17 +3,16 @@ cmake_minimum_required(VERSION 3.29)
 # Suppress CMake's "you are using private Qt headers" warning — we know.
 set(QT_NO_PRIVATE_MODULE_WARNING ON)
 
-# By default, confirmed touch events are re-injected via QWindowSystemInterface,
-# which feeds events through Qt's full input pipeline so TapHandler, DragHandler,
-# and PinchHandler work correctly with transient-filtered touches.  Also enables
-# event-level lift-resume bridging via QMutableEventPoint::setId().
-# Requires Qt private headers (Qt6::GuiPrivate).
-# Set DSQT_TOUCH_NO_PRIVATE_REINJECT=ON to fall back to QCoreApplication::sendEvent.
-option(DSQT_TOUCH_NO_PRIVATE_REINJECT
-    "Disable Qt private-header touch re-injection (fallback to QCoreApplication::sendEvent)"
+# When ON, re-inject confirmed touch events via QWindowSystemInterface rather
+# than QCoreApplication::sendEvent.  This feeds events through Qt's full input
+# pipeline so that TapHandler, DragHandler and PinchHandler work correctly with
+# transient-filtered touches.  Also enables event-level lift-resume bridging via
+# QMutableEventPoint::setId().  Requires Qt private headers (Qt6::GuiPrivate).
+option(DSQT_TOUCH_PRIVATE_REINJECT
+    "Use Qt private headers for proper touch re-injection (enables TapHandler compatibility)"
     OFF)
 
-if(NOT DSQT_TOUCH_NO_PRIVATE_REINJECT)
+if(DSQT_TOUCH_PRIVATE_REINJECT)
     find_package(Qt6 6.9 REQUIRED COMPONENTS GuiPrivate)
 endif()
 
@@ -46,10 +45,9 @@ target_link_libraries(Touch PUBLIC
     Touchplugin
 )
 
-if(NOT DSQT_TOUCH_NO_PRIVATE_REINJECT)
+if(DSQT_TOUCH_PRIVATE_REINJECT)
     target_link_libraries(Touch PUBLIC Qt6::GuiPrivate)
-else()
-    target_compile_definitions(Touch PUBLIC DSQT_TOUCH_NO_PRIVATE_REINJECT)
+    target_compile_definitions(Touch PUBLIC DSQT_TOUCH_PRIVATE_REINJECT)
 endif()
 
 target_include_directories(Touch PUBLIC

--- a/Library/DsQt/Touch/touch/TouchFilter.cpp
+++ b/Library/DsQt/Touch/touch/TouchFilter.cpp
@@ -127,7 +127,7 @@ bool TouchFilter::eventFilter(QObject *watched, QEvent *event)
             emit touchRaw(pt.id(), sp.x(), sp.y(), s);
             emit touchAccepted(pt.id(), sp.x(), sp.y(), sp.x(), sp.y(), s);
         }
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
         // On Windows LWE displays, QEventPoint::scenePosition() == globalPosition()
         // (screen-absolute) instead of being window-relative.  TapHandler and other
         // PointerHandlers check scenePosition() against the item's bounds; with raw LWE
@@ -236,7 +236,7 @@ bool TouchFilter::filterPoint(QTouchEvent *event, const QEventPoint &pt, const Q
                                QStringLiteral("liftResume"));
             emit touchReclassified(id, false, QStringLiteral("liftResume"));
 
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
             // Re-deliver the new press with the OLD touch ID so Qt handlers see
             // one continuous touch (no lift, no new press).
             QEventPoint remapped = pt;
@@ -425,7 +425,7 @@ void TouchFilter::confirmRelease(int id)
 
 void TouchFilter::reInjectEvent(const StoredEvent &ev)
 {
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
     // Use QWindowSystemInterface so the event travels through the full Qt input
     // pipeline (QGuiApplicationPrivate::processTouchEvent → QPointingDevice state
     // update → QQuickDeliveryAgent).  This makes TapHandler, DragHandler, and
@@ -445,7 +445,7 @@ void TouchFilter::reInjectEvent(const StoredEvent &ev)
 #endif
 }
 
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
 QWindowSystemInterface::TouchPoint
 TouchFilter::toTouchPoint(const QEventPoint &pt, QWindow *window)
 {

--- a/Library/DsQt/Touch/touch/TouchFilter.h
+++ b/Library/DsQt/Touch/touch/TouchFilter.h
@@ -8,7 +8,7 @@
 #include <QQuickWindow>
 #include <QTimer>
 
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
 #  include <qpa/qwindowsysteminterface_p.h>
 #  include <private/qeventpoint_p.h>
 #endif
@@ -55,28 +55,27 @@ class QTouchEvent;
 /// treated as a drag continuation in the touchAccepted / touchFiltered signal
 /// stream.
 ///
-/// By default: the new press is suppressed and re-delivered with the old touch
-/// ID via QWindowSystemInterface, making the lift-resume fully transparent to
-/// TapHandler, DragHandler, etc.
-///
-/// With DSQT_TOUCH_NO_PRIVATE_REINJECT: both the release and the new press
+/// Without DSQT_TOUCH_PRIVATE_REINJECT: both the release and the new press
 /// events pass through to Qt's handlers unchanged (signal-level only).
+///
+/// With DSQT_TOUCH_PRIVATE_REINJECT: the new press is suppressed and
+/// re-delivered with the old touch ID via QWindowSystemInterface, making the
+/// lift-resume fully transparent to TapHandler, DragHandler, etc.
 ///
 /// Re-injection note
 /// -----------------
-/// By default, confirmed touches are re-injected via QWindowSystemInterface::handleTouchEvent
-/// (requires Qt6::GuiPrivate), which feeds events through the full Qt input pipeline
-/// so TapHandler / PointerHandler subclasses work correctly.
-///
-/// Build with DSQT_TOUCH_NO_PRIVATE_REINJECT to fall back to QCoreApplication::sendEvent,
-/// which bypasses the pipeline — TapHandler / PointerHandler subclasses may not work reliably.
+/// By default, confirmed touches are re-injected via QCoreApplication::sendEvent.
+/// This bypasses Qt's input pipeline so TapHandler / PointerHandler subclasses
+/// may not receive events reliably.  Build with DSQT_TOUCH_PRIVATE_REINJECT=ON
+/// (requires Qt6::GuiPrivate) to use QWindowSystemInterface::handleTouchEvent
+/// which feeds events through the full pipeline.
 ///
 /// On Windows LWE displays, QEventPoint::scenePosition() == globalPosition()
 /// (screen-absolute) rather than window-relative.  TapHandler checks scenePosition()
 /// against item bounds; raw LWE events fail this check and are rejected.
-/// The default re-injection path re-normalises coordinates so TapHandler works correctly.
-/// With DSQT_TOUCH_NO_PRIVATE_REINJECT the original event is passed through unchanged
-/// and TapHandler may not work.
+/// With DSQT_TOUCH_PRIVATE_REINJECT, even when filterEnabled is false, events are
+/// re-normalised through QWindowSystemInterface so TapHandler works correctly.
+/// Without the flag the original event is passed through and TapHandler may not work.
 class TouchFilter : public QObject
 {
     Q_OBJECT
@@ -115,7 +114,7 @@ public:
     qreal proximityFilterPx()       const { return m_proximityFilterPx;     }
     bool  isFilterEnabled()         const { return m_filterEnabled;          }
     static bool isPrivateReinject() {
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
         return true;
 #else
         return false;
@@ -219,7 +218,7 @@ private:
     static int   stateInt(QEventPoint::State s);
     static qreal dist(QPointF a, QPointF b);
 
-#ifndef DSQT_TOUCH_NO_PRIVATE_REINJECT
+#ifdef DSQT_TOUCH_PRIVATE_REINJECT
     /// Convert a QEventPoint to the structure QWindowSystemInterface expects.
     static QWindowSystemInterface::TouchPoint toTouchPoint(const QEventPoint &pt,
                                                            QWindow *window);

--- a/Library/build_and_install.bat
+++ b/Library/build_and_install.bat
@@ -7,7 +7,7 @@ goto :script_start
 echo[
 echo Usage: build_and_install.bat [preset] [-test] [-tools] [-no-configure] [-no-install] [-clean]
 echo                              [-hard-clean] [-rebuild] [-hard-rebuild] [-qt ^<ver^|path^>]
-echo                              [-no-private-reinject]
+echo                              [-private-reinject]
 echo[
 echo   preset              : CMake configure preset name ^(default: ninja^)
 echo   -test               : Enable and run unit tests after the Debug build
@@ -19,8 +19,8 @@ echo   -hard-clean         : Delete the entire build folder and exit
 echo   -rebuild            : Clean then build ^(cmake clean + full build^)
 echo   -hard-rebuild       : Delete build folder then configure + build + install from scratch
 echo   -qt ^<ver or path^>   : Qt version ^(e.g. 6.10.2^) or full path ^(e.g. C:\Qt\6.10.2\msvc2022_64^)
-echo   -no-private-reinject: Disable private-header touch re-injection ^(falls back to
-echo                         QCoreApplication::sendEvent; private reinject is ON by default^)
+echo   -private-reinject   : Enable DSQT_TOUCH_PRIVATE_REINJECT ^(uses Qt private headers for
+echo                         proper touch re-injection; makes TapHandler work with TouchFilter^)
 echo   -h / -?             : Print usage info and exit
 if defined PRINT_HELP (
   exit /b 0
@@ -48,7 +48,7 @@ set DO_HARD_REBUILD=0
 set BUILD_TOOLS=0
 set PRINT_HELP=0
 set QT_PATH=
-set NO_PRIVATE_REINJECT=0
+set PRIVATE_REINJECT=0
 
 :: Parse arguments — accept preset and flags in any order
 :parse_args
@@ -71,8 +71,8 @@ if /i "%~1"=="-hard-rebuild"  (set DO_HARD_REBUILD=1& shift & goto :parse_args)
 if /i "%~1"=="/hard-rebuild"  (set DO_HARD_REBUILD=1& shift & goto :parse_args)
 if /i "%~1"=="-qt"                  (set QT_PATH=%~2& shift & shift & goto :parse_args)
 if /i "%~1"=="/qt"                  (set QT_PATH=%~2& shift & shift & goto :parse_args)
-if /i "%~1"=="-no-private-reinject" (set NO_PRIVATE_REINJECT=1& shift & goto :parse_args)
-if /i "%~1"=="/no-private-reinject" (set NO_PRIVATE_REINJECT=1& shift & goto :parse_args)
+if /i "%~1"=="-private-reinject"    (set PRIVATE_REINJECT=1& shift & goto :parse_args)
+if /i "%~1"=="/private-reinject"    (set PRIVATE_REINJECT=1& shift & goto :parse_args)
 if /i "%~1"=="-h"            (set PRINT_HELP=1& shift & goto :parse_args)
 if /i "%~1"=="/h"            (set PRINT_HELP=1& shift & goto :parse_args)
 if /i "%~1"=="-?"            (set PRINT_HELP=1& shift & goto :parse_args)
@@ -169,8 +169,8 @@ set CMAKE_CONFIGURE=cmake --preset %PRESET%
 if %RUN_TESTS%==1 (
     set CMAKE_CONFIGURE=%CMAKE_CONFIGURE% -DDSQT_BUILD_TESTS=ON
 )
-if %NO_PRIVATE_REINJECT%==1 (
-    set CMAKE_CONFIGURE=%CMAKE_CONFIGURE% -DDSQT_TOUCH_NO_PRIVATE_REINJECT=ON
+if %PRIVATE_REINJECT%==1 (
+    set CMAKE_CONFIGURE=%CMAKE_CONFIGURE% -DDSQT_TOUCH_PRIVATE_REINJECT=ON
 )
 if defined QT_PATH (
     set CMAKE_CONFIGURE=!CMAKE_CONFIGURE! -DCMAKE_PREFIX_PATH="!QT_PATH!" -DQt6_DIR="!QT_PATH!/lib/cmake/Qt6"
@@ -187,7 +187,7 @@ if %SKIP_CONFIGURE%==1 (
 ) else (
     call :header "Configuring DsQt Library (%PRESET%)"
     if %RUN_TESTS%==1       powershell -NoProfile -Command "Write-Host '    Tests:            ENABLED' -ForegroundColor Yellow"
-    if %NO_PRIVATE_REINJECT%==1 powershell -NoProfile -Command "Write-Host '    Private reinject: DISABLED' -ForegroundColor Yellow"
+    if %PRIVATE_REINJECT%==1 powershell -NoProfile -Command "Write-Host '    Private reinject: ENABLED' -ForegroundColor Yellow"
     call :gettime CONFIGURE_START
     %CMAKE_CONFIGURE%
     if %errorlevel% neq 0 (

--- a/Library/cmake/DsQtConfig.cmake.in
+++ b/Library/cmake/DsQtConfig.cmake.in
@@ -157,11 +157,11 @@ set_target_properties(Dsqt::Waffles PROPERTIES
 _dsqt_create_imported_target(Touch)
 _dsqt_create_plugin_target(Touch)
 set(_dsqt_touch_iface_libs "Qt6::Core;Qt6::Gui;Qt6::Quick;Dsqt::Touchplugin")
-if(NOT @DSQT_TOUCH_NO_PRIVATE_REINJECT@)
+if(@DSQT_TOUCH_PRIVATE_REINJECT@)
     find_dependency(Qt6 REQUIRED COMPONENTS GuiPrivate)
     string(APPEND _dsqt_touch_iface_libs ";Qt6::GuiPrivate")
+    set(DSQT_TOUCH_PRIVATE_REINJECT TRUE)
 endif()
-set(DSQT_TOUCH_NO_PRIVATE_REINJECT @DSQT_TOUCH_NO_PRIVATE_REINJECT@)
 set_target_properties(Dsqt::Touch PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_DSQT_INCLUDE_DIR};${_DSQT_INCLUDE_DIR}/touch"
     INTERFACE_LINK_LIBRARIES      "${_dsqt_touch_iface_libs}"


### PR DESCRIPTION
Reverts Unispace365/DsQt#35 : it somehow failed to find the Touch component when I tried to build using the `main` branch.