### PR TITLE
Added menu items to stop dsapphost (along with ctrl-shift-q)

### DIFF
--- a/Examples/ClonerSource/CMakeLists.txt
+++ b/Examples/ClonerSource/CMakeLists.txt
@@ -56,7 +56,7 @@ project(${DS_APP_NAME} VERSION ${DS_APP_VERSION} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/DEPLOY/")
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/DEPLOY")
 set(QT_FORCE_CMP0156_TO_VALUE NEW)
 set(QT_QML_GENERATE_QMLLS_INI ON)
 find_package(Qt6 6.9 REQUIRED COMPONENTS Core Quick QuickControls2 Multimedia Gui GuiPrivate ShaderTools Concurrent Sql)
@@ -208,6 +208,10 @@ if(Dsqt_TouchEngine_FOUND)
     endif()
 endif()
 
+# Must be the first install() rule — appends the config name to the prefix so
+# Release and Debug deployments land in separate subdirectories.
+install(CODE "set(CMAKE_INSTALL_PREFIX \"\${CMAKE_INSTALL_PREFIX}/\${CMAKE_INSTALL_CONFIG_NAME}\")")
+
 install(TARGETS ${DS_EXE_NAME}
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -222,14 +226,22 @@ if(WIN32 AND Dsqt_TouchEngine_FOUND)
     install(FILES "${DSQT_BIN_DIR}/$<CONFIG>/TouchEngine.dll" DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
 endif()
 
-# Install vcpkg runtime dependencies (tomlplusplus, etc.)
-# vcpkg in manifest mode installs DLLs to vcpkg_installed/x64-windows/bin
+# Install vcpkg runtime dependencies — select debug or release DLLs at install time.
+# file(GLOB) runs at configure time so it can't use $<CONFIG>; install(CODE) defers
+# the glob until cmake --install runs, when CMAKE_INSTALL_CONFIG_NAME is known.
 if(WIN32)
-    # Install all DLLs from vcpkg manifest installation
-    file(GLOB VCPKG_RUNTIME_DLLS "${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows/bin/*.dll")
-    if(VCPKG_RUNTIME_DLLS)
-        install(FILES ${VCPKG_RUNTIME_DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
-    endif()
+    install(CODE "
+        if(\"\${CMAKE_INSTALL_CONFIG_NAME}\" STREQUAL \"Debug\")
+            set(_vcpkg_bin \"${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows/debug/bin\")
+        else()
+            set(_vcpkg_bin \"${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows/bin\")
+        endif()
+        file(GLOB _dlls \"\${_vcpkg_bin}/*.dll\")
+        if(_dlls)
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\"
+                 TYPE FILE FILES \${_dlls})
+        endif()
+    ")
 endif()
 
 qt_generate_deploy_qml_app_script(

--- a/Examples/ClonerSource/cmake/inno.iss.in
+++ b/Examples/ClonerSource/cmake/inno.iss.in
@@ -2,7 +2,7 @@
 ; this is the location of the DEPLOY Folder, which should contain the built
 ;executable and all necessary files to run the app. This is used to pull in
 ;the version number from the executable, so it needs to be correct for that to work.
-#define BASEDIR "@CMAKE_INSTALL_PREFIX@"
+#define BASEDIR "@CMAKE_INSTALL_PREFIX@/Release"
 ; What displays in the start menu, also used as the Unique app name / id
 #define APP_DISPLAY_NAME "@DS_APP_NAME@"
 ; Used for paths for the app directory. Recommend using the auto-generated values

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -26,6 +26,15 @@ set(QT_FORCE_CMP0156_TO_VALUE NEW)
 # Consolidate all QML module output into a single directory structure
 set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml")
 
+# Tell Qt Creator (and other IDEs) where to find the built QML modules.
+set(QML_TMP_PATH "${QT_QML_OUTPUT_DIRECTORY};${QML_IMPORT_PATH}")
+list(REMOVE_DUPLICATES QML_TMP_PATH)
+set(QML_IMPORT_PATH "${QML_TMP_PATH}" CACHE PATH "Qt Creator QML import path" FORCE)
+
+# Regenerate .qmlls.ini files in each module's source directory so qmlls
+# points at this build's output rather than any previously cached build.
+set(QT_QML_GENERATE_QMLLS_INI ON)
+
 if(PROJECT_IS_TOP_LEVEL)
     find_package(Doxygen COMPONENTS dot)
     option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" ${DOXYGEN_FOUND})

--- a/Library/DsQt/Core/CMakeLists.txt
+++ b/Library/DsQt/Core/CMakeLists.txt
@@ -100,7 +100,8 @@ qt_add_qml_module(Core
         res/keyboard.qrc
         res/data.qrc
 
-        QML_FILES 
+        QML_FILES
+        SOURCES core/dsQmlAppHost.h core/dsQmlAppHost.cpp
 )
 
 set(CoreTargets ${CoreTargets} PARENT_SCOPE)

--- a/Library/DsQt/Core/core/dsQmlAppHost.cpp
+++ b/Library/DsQt/Core/core/dsQmlAppHost.cpp
@@ -1,0 +1,23 @@
+#include "dsQmlAppHost.h"
+#include "QNetworkAccessManager"
+#include "QNetworkReply"
+#include "QNetworkRequest"
+#include "dsSettings.h"
+
+namespace dsqt {
+DsQmlAppHost::DsQmlAppHost(QObject* parent)
+    : QObject{parent} {
+    DsSettingsRef settingsEng = DsSettings::getSettings("engine");
+
+    baseUrl.setUrl(settingsEng->getOr("appHost.baseUrl",QString("http://localhost:7800")));
+    manager = new QNetworkAccessManager(this);
+}
+
+void DsQmlAppHost::exit()
+{
+    QUrl exit("api/exit");
+    auto response = manager->get(QNetworkRequest(baseUrl.resolved(exit)));
+}
+
+
+}

--- a/Library/DsQt/Core/core/dsQmlAppHost.cpp
+++ b/Library/DsQt/Core/core/dsQmlAppHost.cpp
@@ -3,6 +3,7 @@
 #include "QNetworkReply"
 #include "QNetworkRequest"
 #include "dsSettings.h"
+#include <qguiapplication.h>
 
 namespace dsqt {
 DsQmlAppHost::DsQmlAppHost(QObject* parent)
@@ -13,10 +14,16 @@ DsQmlAppHost::DsQmlAppHost(QObject* parent)
     manager = new QNetworkAccessManager(this);
 }
 
-void DsQmlAppHost::exit()
+void DsQmlAppHost::exit(bool quit)
 {
     QUrl exit("api/exit");
     auto response = manager->get(QNetworkRequest(baseUrl.resolved(exit)));
+    connect(response,&QNetworkReply::finished,this,[this,quit](){
+        if(quit){
+            qApp->quit();
+        }
+    });
+
 }
 
 

--- a/Library/DsQt/Core/core/dsQmlAppHost.h
+++ b/Library/DsQt/Core/core/dsQmlAppHost.h
@@ -15,7 +15,7 @@ class DsQmlAppHost : public QObject {
   public:
     explicit DsQmlAppHost(QObject* parent = nullptr);
 
-    Q_INVOKABLE void exit();
+    Q_INVOKABLE void exit(bool quit=false);
 
   signals:
   private:

--- a/Library/DsQt/Core/core/dsQmlAppHost.h
+++ b/Library/DsQt/Core/core/dsQmlAppHost.h
@@ -1,0 +1,26 @@
+#ifndef DSQMLAPPHOST_H
+#define DSQMLAPPHOST_H
+
+#include <QObject>
+#include <QQmlEngine>
+
+
+class QNetworkAccessManager;
+class QUrl;
+namespace dsqt {
+class DsQmlAppHost : public QObject {
+    Q_OBJECT
+    QML_SINGLETON
+    QML_NAMED_ELEMENT(AppHost)
+  public:
+    explicit DsQmlAppHost(QObject* parent = nullptr);
+
+    Q_INVOKABLE void exit();
+
+  signals:
+  private:
+    QNetworkAccessManager* manager;
+    QUrl baseUrl;
+};
+}
+#endif // DSQMLAPPHOST_H

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
@@ -7,6 +7,7 @@
 #include "network/dsNodeWatcher.h"
 #include "settings/dsQmlSettingsProxy.h"
 #include "core/dsFontManager.h"
+#include "core/dsQmlAppHost.h"
 
 #include <QDir>
 #include <QDirIterator>
@@ -264,6 +265,16 @@ DsQmlSettingsProxy* DsQmlApplicationEngine::getAppSettingsProxy() const {
 
 DsQmlIdle* DsQmlApplicationEngine::idle() const {
     return mIdle;
+}
+
+void DsQmlApplicationEngine::quit()
+{
+    //if engine.askAppHostToQuit is set send message to DsAppHost
+    auto engSetting = dsqt::DsSettings::getSettings("engine");
+    if(engSetting && engSetting->getOr<bool>("appHost.exitOnQuit",true)){
+        DsQmlAppHost* appHost = this->singletonInstance<DsQmlAppHost*>("","AppHost");
+        appHost->exit();
+    }
 }
 
 } // namespace dsqt

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
@@ -267,14 +267,19 @@ DsQmlIdle* DsQmlApplicationEngine::idle() const {
     return mIdle;
 }
 
-void DsQmlApplicationEngine::quit()
+void DsQmlApplicationEngine::quit(bool force)
 {
     //if engine.askAppHostToQuit is set send message to DsAppHost
     auto engSetting = dsqt::DsSettings::getSettings("engine");
-    if(engSetting && engSetting->getOr<bool>("appHost.exitOnQuit",true)){
-        DsQmlAppHost* appHost = this->singletonInstance<DsQmlAppHost*>("","AppHost");
-        appHost->exit();
+    auto exitOnQuit = engSetting->getOr("appHost.exitOnQuit",false);
+
+    DsQmlAppHost* appHost = new DsQmlAppHost(this);
+    if(exitOnQuit || force){
+        appHost->exit(true);
+    } else {
+        qApp->quit();
     }
+
 }
 
 } // namespace dsqt

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.h
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.h
@@ -133,6 +133,11 @@ class DsQmlApplicationEngine : public QQmlApplicationEngine {
      */
     DsQmlIdle* idle() const;
 
+    /**
+     * @brief controlled exit
+     */
+    Q_INVOKABLE void quit();
+
 
   private:
     /**

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.h
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.h
@@ -136,7 +136,7 @@ class DsQmlApplicationEngine : public QQmlApplicationEngine {
     /**
      * @brief controlled exit
      */
-    Q_INVOKABLE void quit();
+    Q_INVOKABLE void quit(bool force=false);
 
 
   private:

--- a/Library/DsQt/Core/qml/DsAppBase.qml
+++ b/Library/DsQt/Core/qml/DsAppBase.qml
@@ -80,7 +80,7 @@ ApplicationWindow {
         sequence: "ESCAPE"
         autoRepeat: false
         context: Qt.ApplicationShortcut
-        onActivated: Qt.quit()
+        onActivated: Ds.engine.quit(false)
     }
 
     /// Provides access to the window settings.

--- a/Library/DsQt/Core/qml/DsAppMenuBar.qml
+++ b/Library/DsQt/Core/qml/DsAppMenuBar.qml
@@ -45,15 +45,9 @@ MenuBar {
 
         Action {
             text: "Stop AppHost"
-            shortcut: "CTRL+SHIFT+Q"
             onTriggered: AppHost.exit()
         }
 
-        Action {
-            text: "Quit"
-            shortcut: "CTRL+Q"
-            onTriggered: Qt.quit()
-        }
     }
     Menu {
         id: logsMenu

--- a/Library/DsQt/Core/qml/DsAppMenuBar.qml
+++ b/Library/DsQt/Core/qml/DsAppMenuBar.qml
@@ -21,6 +21,18 @@ MenuBar {
     property alias contentBrowseChecked: contentBrowseAction.checked
     property alias touchFilterDebugChecked: touchFilterDebugAction.checked
 
+
+    contentItem: Item {
+        implicitHeight: row.implicitHeight
+        Row {
+            id: row
+            anchors.centerIn: parent
+            Repeater {
+                model: menuBar.contentModel
+            }
+        }
+    }
+
     Menu {
         id: fileMenu
         title: "File"
@@ -32,20 +44,21 @@ MenuBar {
         // }
         // MenuSeparator {}
         Action {
-            text: "Quit"
-            shortcut: "CTRL+Q"
-            onTriggered: Qt.quit()
+            text: "Stop AppHost"
+            onTriggered: AppHost.exit()
         }
 
         Action {
             text: "Quit and Stop AppHost"
             shortcut: "CTRL+SHIFT+Q"
-            onTriggered: Ds.engine.quit()
+            onTriggered: Ds.engine.quit(true)
         }
 
+        //Quit should always be last.
         Action {
-            text: "Stop AppHost"
-            onTriggered: AppHost.exit()
+            text: "Quit"
+            shortcut: "CTRL+Q"
+            onTriggered: Ds.engine.quit(false)
         }
 
     }

--- a/Library/DsQt/Core/qml/DsAppMenuBar.qml
+++ b/Library/DsQt/Core/qml/DsAppMenuBar.qml
@@ -36,6 +36,24 @@ MenuBar {
             shortcut: "CTRL+Q"
             onTriggered: Qt.quit()
         }
+
+        Action {
+            text: "Quit and Stop AppHost"
+            shortcut: "CTRL+SHIFT+Q"
+            onTriggered: Ds.engine.quit()
+        }
+
+        Action {
+            text: "Stop AppHost"
+            shortcut: "CTRL+SHIFT+Q"
+            onTriggered: AppHost.exit()
+        }
+
+        Action {
+            text: "Quit"
+            shortcut: "CTRL+Q"
+            onTriggered: Qt.quit()
+        }
     }
     Menu {
         id: logsMenu

--- a/Tools/ProjectCloner/cloner.cpp
+++ b/Tools/ProjectCloner/cloner.cpp
@@ -97,7 +97,7 @@ void Cloner::clone()
             success = success && replaceInFile(destDirectory.absoluteFilePath("settings/engine.toml"),"ClonerSource",m_applicationName);
             success = success && replaceInFile(destDirectory.absoluteFilePath("CMakeLists.txt"),"ClonerSource",m_applicationName);
             success = success && replaceInFile(destDirectory.absoluteFilePath("CMakeLists.txt"),"PROJECT_NAME_",substitutionName);
-            success = success && replaceInFile(destDirectory.absoluteFilePath("CMakeLists.txt"),"PROJECT_DESC_",m_description);
+            success = success && replaceInFile(destDirectory.absoluteFilePath("CMakeLists.txt"),"PROJECT_DESC_",m_applicationName);
             success = success && replaceInFile(destDirectory.absoluteFilePath("README.md"),"PROJECT_NAME_",substitutionName);
             success = success && replaceInFile(destDirectory.absoluteFilePath("README.md"),"APP_NAME_",m_applicationName);
             //update README.md in project dir

--- a/Tools/ProjectCloner/cloner.h
+++ b/Tools/ProjectCloner/cloner.h
@@ -104,7 +104,6 @@ private:
     QList<QString> m_excludeList;
     QList<QString> m_permanentExcludeList = {"CMakeLists.txt.user","build\\"};
     QString m_lastError;
-    QString m_description = "Another fine Downstream production.";
 
 private:
     bool processDirectory(QDir dir,QDir rootDir);


### PR DESCRIPTION
This adds the QML AppHost singleton, which currently has one method of exit(), which asks DsAppHost to exit.
adds the following menu commands:

Quit and Stop AppHost 
Stop AppHost

Quit and Stop AppHost can be triggered by CTRL-SHIFT-Q