### PR TITLE
Added Ds.engineSettings as accessible from QML.

### DIFF
--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
@@ -164,14 +164,12 @@ void dsqt::DsQmlApplicationEngine::readSettings(bool reset) {
 void DsQmlApplicationEngine::init() {
     // setup nodeWatcher
     readSettings();
+    if (!mEngineProxy) mEngineProxy = new DsQmlSettingsProxy(this);
     if (!mAppProxy) mAppProxy = new DsQmlSettingsProxy(this);
     // auto starts, but could also be this:
     // mNodeWatcher = new network::DsNodeWatcher(this,"localhost",7788,/*autostart*/false)
     // mNodeWatcher->start();
 
-    readSettings();
-    mAppProxy = new DsQmlSettingsProxy(this);
-    mQmlEnv   = new DsQmlEnvironment(this);
     // get watcher elements
     auto node = dsqt::DsEnvironment::engineSettings()->getRawNode("engine.reload.paths");
     if (node) {
@@ -197,6 +195,7 @@ void DsQmlApplicationEngine::init() {
     mIdle->setIdleTimeout(timeoutInSeconds * 1000);
     mIdle->startIdling(true);
 
+    mEngineProxy->setTarget("engine");
     mAppProxy->setTarget("app_settings");
 
     //lets load som fernts
@@ -256,6 +255,10 @@ void DsQmlApplicationEngine::clearQmlCache() {
 
 DsQmlEnvironment* DsQmlApplicationEngine::getEnvQml() const {
     return mQmlEnv;
+}
+
+DsQmlSettingsProxy* DsQmlApplicationEngine::getEngineSettingsProxy() const {
+    return mEngineProxy;
 }
 
 DsQmlSettingsProxy* DsQmlApplicationEngine::getAppSettingsProxy() const {

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.h
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.h
@@ -110,6 +110,12 @@ class DsQmlApplicationEngine : public QQmlApplicationEngine {
     DsQmlEnvironment* getEnvQml() const;
 
     /**
+     * @brief Gets the engine settings proxy.
+     * @return Pointer to DsQmlSettingsProxy.
+     */
+    DsQmlSettingsProxy* getEngineSettingsProxy() const;
+
+    /**
      * @brief Gets the application settings proxy.
      * @return Pointer to DsQmlSettingsProxy.
      */
@@ -236,6 +242,9 @@ class DsQmlApplicationEngine : public QQmlApplicationEngine {
 
     /// Timer for triggering resets.
     QTimer mTrigger;
+
+    /// Pointer to the engine settings proxy.
+    DsQmlSettingsProxy* mEngineProxy = nullptr;
 
     /// Pointer to the application settings proxy.
     DsQmlSettingsProxy* mAppProxy = nullptr;

--- a/Library/DsQt/Core/core/dsQmlObj.cpp
+++ b/Library/DsQt/Core/core/dsQmlObj.cpp
@@ -21,6 +21,11 @@ DsQmlObj* DsQmlObj::create(QQmlEngine* qmlEngine, QJSEngine* jsEngine) {
     return new DsQmlObj(qmlEngine, jsEngine);
 }
 
+DsQmlSettingsProxy* DsQmlObj::engineSettings() const {
+    if (!mEngine) return nullptr;
+    return mEngine->getEngineSettingsProxy();
+}
+
 DsQmlSettingsProxy* DsQmlObj::appSettings() const {
     if (!mEngine) return nullptr;
     return mEngine->getAppSettingsProxy();

--- a/Library/DsQt/Core/core/dsQmlObj.h
+++ b/Library/DsQt/Core/core/dsQmlObj.h
@@ -34,6 +34,7 @@ class DsQmlObj : public QObject {
     QML_NAMED_ELEMENT(Ds)
 
     Q_PROPERTY(dsqt::DsQmlEnvironment* env READ env CONSTANT)
+    Q_PROPERTY(dsqt::DsQmlSettingsProxy* engineSettings READ engineSettings CONSTANT)
     Q_PROPERTY(dsqt::DsQmlSettingsProxy* appSettings READ appSettings CONSTANT)
     Q_PROPERTY(dsqt::DsQmlApplicationEngine* engine READ engine CONSTANT)
     Q_PROPERTY(dsqt::DsQmlPathHelper* path READ path CONSTANT)
@@ -54,6 +55,12 @@ class DsQmlObj : public QObject {
      * \return Pointer to the newly created DsQmlObj instance.
      */
     static DsQmlObj* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine = nullptr);
+
+    /**
+     * \brief Getter for the engine settings proxy.
+     * \return Pointer to DsQmlSettingsProxy, or nullptr if the engine is not available.
+     */
+    DsQmlSettingsProxy* engineSettings() const;
 
     /**
      * \brief Getter for the application settings proxy.


### PR DESCRIPTION
I love using `Ds.appSettings` as a quick way to access application settings. Thought we'd do the same for the engine settings.