### PR TITLE
Added Kiosk/UnKiosk/restart to new apphost 'e' menu

### DIFF
--- a/Library/DsQt/Core/core/dsQmlAppHost.cpp
+++ b/Library/DsQt/Core/core/dsQmlAppHost.cpp
@@ -26,5 +26,51 @@ void DsQmlAppHost::exit(bool quit)
 
 }
 
+void DsQmlAppHost::kiosk()
+{
+    {
+        QUrl doKiosk("api/kiosk");
+        auto response = manager->get(QNetworkRequest(baseUrl.resolved(doKiosk)));
+        connect(response,&QNetworkReply::finished,this, [this]{});
+    }
+
+    {
+        QUrl alwaysOnTop("api/alwaysontop/reset");
+        auto response = manager->get(QNetworkRequest(baseUrl.resolved(alwaysOnTop)));
+        connect(response,&QNetworkReply::finished,this, [this]{});
+    }
+}
+
+void DsQmlAppHost::unkiosk()
+{
+    {
+        QUrl doUnKiosk("api/unkiosk");
+        auto response = manager->get(QNetworkRequest(baseUrl.resolved(doUnKiosk)));
+        connect(response,&QNetworkReply::finished,this, [this]{});
+    }
+
+    {
+        QUrl noAlwaysOnTop("api/alwaysontop/disable");
+        auto response = manager->get(QNetworkRequest(baseUrl.resolved(noAlwaysOnTop)));
+        connect(response,&QNetworkReply::finished,this, [this]{});
+    }
+}
+
+void DsQmlAppHost::reconfigure()
+{
+    QUrl doReconfigure("api/Reconfigure");
+    auto response = manager->get(QNetworkRequest(baseUrl.resolved(doReconfigure)));
+    connect(response,&QNetworkReply::finished,this, [this]{});
+}
+
+// QString DsQmlAppHost::getStatus()
+// {
+//     QUrl doReconfigure("api/Status");
+//     auto response = manager->get(QNetworkRequest(baseUrl.resolved(doReconfigure)));
+//     connect(response,&QNetworkReply::finished,this, [this, response]{
+//         qInfo() << response->readAll();
+//       });
+//     return QString();
+// }
 
 }

--- a/Library/DsQt/Core/core/dsQmlAppHost.h
+++ b/Library/DsQt/Core/core/dsQmlAppHost.h
@@ -17,6 +17,13 @@ class DsQmlAppHost : public QObject {
 
     Q_INVOKABLE void exit(bool quit=false);
 
+    Q_INVOKABLE void kiosk();
+    Q_INVOKABLE void unkiosk();
+
+    Q_INVOKABLE void reconfigure();
+
+    // Q_INVOKABLE QString getStatus();
+
   signals:
   private:
     QNetworkAccessManager* manager;

--- a/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
+++ b/Library/DsQt/Core/core/dsQmlApplicationEngine.cpp
@@ -167,6 +167,8 @@ void DsQmlApplicationEngine::init() {
     readSettings();
     if (!mEngineProxy) mEngineProxy = new DsQmlSettingsProxy(this);
     if (!mAppProxy) mAppProxy = new DsQmlSettingsProxy(this);
+    if (!mQmlEnv) mQmlEnv = new DsQmlEnvironment(this);
+
     // auto starts, but could also be this:
     // mNodeWatcher = new network::DsNodeWatcher(this,"localhost",7788,/*autostart*/false)
     // mNodeWatcher->start();

--- a/Library/DsQt/Core/qml/DsAppMenuBar.qml
+++ b/Library/DsQt/Core/qml/DsAppMenuBar.qml
@@ -43,10 +43,6 @@ MenuBar {
         //     onTriggered: menuBar.fileInfoTriggered()
         // }
         // MenuSeparator {}
-        Action {
-            text: "Stop AppHost"
-            onTriggered: AppHost.exit()
-        }
 
         Action {
             text: "Quit and Stop AppHost"
@@ -61,6 +57,35 @@ MenuBar {
             onTriggered: Ds.engine.quit(false)
         }
 
+    }
+    Menu {
+        id: apphostMenu
+        title: "AppHost"
+        width: 200
+        Action {
+            text: "Stop AppHost"
+            onTriggered: AppHost.exit()
+        }
+
+        Action {
+            text: "Kiosk"
+            onTriggered: AppHost.kiosk()
+        }
+
+        Action {
+            text: "Un-Kiosk"
+            onTriggered: AppHost.unkiosk()
+        }
+
+        Action {
+            text: "Restart AppHost"
+            onTriggered: AppHost.reconfigure()
+        }
+
+        // Action {
+        //     text: "Status"
+        //     onTriggered: AppHost.getStatus()
+        // }
     }
     Menu {
         id: logsMenu


### PR DESCRIPTION
- Unkiosk restarts explorer and disables any alwaysOnTop settings
- Kiosk will kill explorer and reset any alwaysOnTop settings
- Restart will trigger apphost to reconfigure (reload config and restart all apps)
- Moved the 'Stop AppHost' item to the AppHost menu

Depends on changes to dsapphost that have been added to this PR https://github.com/Unispace365/DSAppHost/pull/4