### PR TITLE
Fix bridge related crashing

### DIFF
--- a/Library/DsQt/Bridge/bridge/dsBridgeQuery.cpp
+++ b/Library/DsQt/Bridge/bridge/dsBridgeQuery.cpp
@@ -296,16 +296,9 @@ void DsBridgeSqlQuery::onProcessContent() {
     }
 
     if (mContent.m_queue.isEmpty()) {
-        // Done processing. Setup content linking.
-        mContent.m_queue = mContent.m_records.keys();
-        if (mContent.m_queue.isEmpty()) {
-            // Nothing to link or sort. Go straight to cleaning up stale content so that bridge signals are emitted.
-            mContent.m_queue = ContentLookup::get().keys();
-            QTimer::singleShot(1, this, &DsBridgeSqlQuery::onCleanContent);
-        } else {
-            // We're going to link all content in chunks, so that we do not affect the main thread too much.
-            QTimer::singleShot(1, this, &DsBridgeSqlQuery::onLinkContent);
-        }
+        // Done processing. Setup content CLEANING first!
+        mContent.m_queue = ContentLookup::get().keys();
+        QTimer::singleShot(1, this, &DsBridgeSqlQuery::onCleanContent);
     } else {
         // Process next chunk later.
         QTimer::singleShot(1, this, &DsBridgeSqlQuery::onProcessContent);
@@ -329,14 +322,7 @@ void DsBridgeSqlQuery::onLinkContent() {
     if (mContent.m_queue.isEmpty()) {
         // Done linking. Setup content sorting.
         mContent.m_queue = mContent.m_records.keys();
-        if (mContent.m_queue.isEmpty()) {
-            // Nothing to sort. Go straight to cleaning up stale content so that bridge signals are emitted.
-            mContent.m_queue = ContentLookup::get().keys();
-            QTimer::singleShot(1, this, &DsBridgeSqlQuery::onCleanContent);
-        } else {
-            // We're going to sort all content in chunks, so that we do not affect the main thread too much.
-            QTimer::singleShot(1, this, &DsBridgeSqlQuery::onSortContent);
-        }
+        QTimer::singleShot(1, this, &DsBridgeSqlQuery::onSortContent);
     } else {
         // Link next chunk later.
         QTimer::singleShot(1, this, &DsBridgeSqlQuery::onLinkContent);
@@ -366,10 +352,8 @@ void DsBridgeSqlQuery::onSortContent() {
     }
 
     if (mContent.m_queue.isEmpty()) {
-        // Done sorting. Setup content cleaning.
-        mContent.m_queue = ContentLookup::get().keys();
-        // Always proceed to onCleanContent so that bridge signals are emitted even when there is nothing to clean.
-        QTimer::singleShot(1, this, &DsBridgeSqlQuery::onCleanContent);
+        // Done sorting. Move to the final publish stage
+        QTimer::singleShot(1, this, &DsBridgeSqlQuery::onPublishContent);
     } else {
         // Sort next chunk later.
         QTimer::singleShot(1, this, &DsBridgeSqlQuery::onSortContent);
@@ -393,55 +377,64 @@ void DsBridgeSqlQuery::onCleanContent() {
     }
 
     if (mContent.m_queue.isEmpty()) {
-        // Done cleaning.
-        mIsRunning.testAndSetRelaxed(true, false);
-
-        Q_ASSERT(QThread::currentThread() == QCoreApplication::instance()->thread());
-
-        // Construct or update the content tree.
-        auto& bridge = bridge::DsQmlBridge::instance();
-        auto  root   = bridge.content();
-
-        auto content = root->getChildByName("Content");
-        if (!content) content = ContentModel::createNamed("Content", root);
-        auto events = root->getChildByName("Events");
-        if (!events) events = ContentModel::createNamed("Events", root);
-        auto platforms = root->getChildByName("Platforms");
-        if (!platforms) platforms = ContentModel::createNamed("Platforms", root);
-
-        // Update root.
-        root->setProperty("content_uid", mContent.m_content);
-        root->setProperty("event_uid", mContent.m_events);
-        root->setProperty("platform_uid", mContent.m_platforms);
-
-        for (const auto& uid : std::as_const(mContent.m_content)) {
-            auto val = ContentModel::find(uid);
-            if (val) {
-                val->setParent(content);
-            }
-        }
-        for (const auto& uid : std::as_const(mContent.m_events)) {
-            auto val = ContentModel::find(uid);
-            if (val) {
-                val->setParent(events);
-            }
-        }
-        for (const auto& uid : std::as_const(mContent.m_platforms)) {
-            auto val = ContentModel::find(uid);
-            if (val) {
-                val->setParent(platforms);
-            }
-        }
-
-        // Update root and emit contentChanged() signal.
-        bridge.setContent(root);
-
-        // Update thread-safe database and emit databaseChanged() signal.
-        bridge.setDatabase(std::move(mContent));
+        // Done cleaning. Setup content linking.
+        mContent.m_queue = mContent.m_records.keys();
+        QTimer::singleShot(1, this, &DsBridgeSqlQuery::onLinkContent);
     } else {
         // Clean next chunk later.
         QTimer::singleShot(1, this, &DsBridgeSqlQuery::onCleanContent);
     }
+}
+
+void DsBridgeSqlQuery::onPublishContent() {
+    qCDebug(lgBridgeSyncQueryVerbose) << "Publish content";
+
+    mIsRunning.testAndSetRelaxed(true, false);
+
+    Q_ASSERT(QThread::currentThread() == QCoreApplication::instance()->thread());
+
+    // Construct or update the content tree.
+    auto& bridge = bridge::DsQmlBridge::instance();
+    auto  root   = bridge.content();
+
+    auto content = root->getChildByName("Content");
+    if (!content) content = ContentModel::createNamed("Content", root);
+    auto events = root->getChildByName("Events");
+    if (!events) events = ContentModel::createNamed("Events", root);
+    auto platforms = root->getChildByName("Platforms");
+    if (!platforms) platforms = ContentModel::createNamed("Platforms", root);
+
+    // Update root.
+    root->setProperty("content_uid", mContent.m_content);
+    root->setProperty("event_uid", mContent.m_events);
+    root->setProperty("platform_uid", mContent.m_platforms);
+
+    for (const auto& uid : std::as_const(mContent.m_content)) {
+        auto val = ContentModel::find(uid);
+        if (val) {
+            val->setParent(content);
+        }
+    }
+    for (const auto& uid : std::as_const(mContent.m_events)) {
+        auto val = ContentModel::find(uid);
+        if (val) {
+            val->setParent(events);
+        }
+    }
+    for (const auto& uid : std::as_const(mContent.m_platforms)) {
+        auto val = ContentModel::find(uid);
+        if (val) {
+            val->setParent(platforms);
+        }
+    }
+
+    // Update root and emit contentChanged() signal.
+    bridge.setContent(root);
+
+    // Update thread-safe database and emit databaseChanged() signal.
+    bridge.setDatabase(std::move(mContent));
+
+    qCDebug(lgBridgeSyncQuery) << "Database sync pipeline complete.";
 }
 
 void DsBridgeSqlQuery::queryDatabase() {

--- a/Library/DsQt/Bridge/bridge/dsBridgeQuery.h
+++ b/Library/DsQt/Bridge/bridge/dsBridgeQuery.h
@@ -201,12 +201,14 @@ class DsBridgeSqlQuery : public QObject {
     void onUpdated();
     // Create content records on the main thread.
     void onProcessContent();
-    // Make sure all content records are linked up (parent-child relations are enforced).
-    void onLinkContent();
-    //
-    void onSortContent();
     // Make sure obsolete content records are deleted.
     void onCleanContent();
+    // Make sure all content records are linked up (parent-child relations are enforced).
+    void onLinkContent();
+    // Sort children by rank and set the "children" property on ContentModel records
+    void onSortContent();
+    // Final step in the content processing pipeline
+    void onPublishContent();
 
   private:
     /**

--- a/Library/DsQt/Core/model/dsContentModel.h
+++ b/Library/DsQt/Core/model/dsContentModel.h
@@ -395,11 +395,11 @@ class ContentModel : public QQmlPropertyMap {
         const auto parent_uids = getProperty<QStringList>("parent_uid");
 
         // If a record has multiple parents, we don't want it to exist in the object tree.
-        // We MUST sever the link to the old parent if was a prior parent/childr relationship,
-        // i.e. The CMS changed from:
-        //   parent_id = [A]
+        // We MUST sever the link to the old parent if it was a prior parent/child relationship,
+        // i.e. the CMS changed from:
+        //   parent_uid = [A]
         // to this:
-        //   parent_id = [B, C]
+        //   parent_uid = [B, C]
         if (parent_uids.size() != 1) {
             setParent(nullptr);
             return;

--- a/Library/DsQt/Core/model/dsContentModel.h
+++ b/Library/DsQt/Core/model/dsContentModel.h
@@ -393,15 +393,28 @@ class ContentModel : public QQmlPropertyMap {
 
         const auto uid         = getProperty<QString>("uid");
         const auto parent_uids = getProperty<QStringList>("parent_uid");
+
+        // If a record has multiple parents, we don't want it to exist in the object tree.
+        // We MUST sever the link to the old parent if was a prior parent/childr relationship,
+        // i.e. The CMS changed from:
+        //   parent_id = [A]
+        // to this:
+        //   parent_id = [B, C]
+        if (parent_uids.size() != 1) {
+            setParent(nullptr);
+            return;
+        }
+
+        // Otherwise, we know that it has exactly one parent
+        // Link records with a single parent to the parent node.
         for (const auto& parent_uid : parent_uids) {
             auto parent = find(parent_uid);
             if (parent) {
-                // Link records with a single parent to the parent node.
-                if (parent_uids.size() == 1) setParent(parent);
-                // // Always add child uid to parent's list of childs.
-                // auto childs = parent->value("child_uid").toStringList();
-                // if (!childs.contains(uid)) childs.append(uid);
-                // parent->insert("child_uid", childs);
+                setParent(parent);
+            } else {
+                // Safety fallback: If for some reason we can't find the parent yet/anymore,
+                // ensure this child doesn't stay attached to a stale old parent
+                setParent(nullptr);
             }
         }
     }

--- a/Library/DsQt/Core/model/dsContentModel.h
+++ b/Library/DsQt/Core/model/dsContentModel.h
@@ -170,6 +170,7 @@ class ContentModel : public QQmlPropertyMap {
         auto&      lookup = ContentLookup::get();
         const auto itr    = lookup.constFind(uid);
         if (itr != lookup.constEnd()) {
+            itr.value()->setParent(nullptr);
             itr.value()->deleteLater();
             lookup.erase(itr);
         }
@@ -180,6 +181,7 @@ class ContentModel : public QQmlPropertyMap {
         for (const auto& uid : uids) {
             const auto itr = lookup.constFind(uid);
             if (itr != lookup.constEnd()) {
+                itr.value()->setParent(nullptr);
                 itr.value()->deleteLater();
                 lookup.erase(itr);
             }


### PR DESCRIPTION
Previously the ContentModel main-thread processing pipeline was:
    `Process -> Link -> Sort -> Clean -> Publish`
    Where this happens in each stage:
    
        - Process: Create or Update ContentModels
        - Link:    Call QObject::setParent() on ContentModel instances, according to their parent_uid arrays
        - Sort:    Sort each ContentModels' children (from QObject::children()) according to CMS-provided rank
                 Set the QML properties: child_uid and children
        - Clean:   Remove any records in the lookup that are no longer in the most recent query-constructed DatabaseContent (mContent)
                 Do this by calling deleteNow() which calls QObject deleteLater(), more on this later...

The problem is, the Clean stage needs to remove any CMS-deleted records from the ContentModel's QObject parent/children linkage BEFORE the `child_uid` and `children` properities are being set, otherwise, we end up with dangling
pointers to (about-to-be deleted) records in QML children array. 
The solution is to change the order to:
`Process -> Clean -> Link -> Sort -> Publish`
This ensures that Sort will have the correct parent/child
relationships for populate the QML `child_uid` and `children` properties

Furthermore, ContentModel's `deleteNow()` method is a misnomer, it actually calls QObject's `deleteLater()`.
* This means that the QObject `children()` array (which is different from the QML `children` property) will still incorrectly contain the deleted child, and the Sort phase will still pick this up
* Solution is to immediately setParent to nullptr when `deleteNow()` is called