### PR TITLE
New VCPKG workflow.

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -68,6 +68,7 @@ jobs:
         -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake"
         -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install"
         -DDSQT_BUILD_TESTS=ON
+        -DDSQT_BUNDLE_DEPENDENCIES=OFF
 
     - name: Build Release
       shell: cmd

--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -1,0 +1,68 @@
+name: Update vcpkg Registry
+
+on:
+  workflow_run:
+    workflows: ["Build Library"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  update-registry:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout vcpkg-registry
+      uses: actions/checkout@v4
+      with:
+        repository: Unispace365/vcpkg-registry
+        token: ${{ secrets.REGISTRY_PAT }}
+
+    - name: Get new DsQt commit SHA
+      id: dsqt
+      shell: bash
+      run: |
+        SHA=$(curl -s https://api.github.com/repos/Unispace365/DsQt/commits/main \
+          | jq -r '.sha')
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+    - name: Update portfile REF
+      shell: bash
+      run: |
+        sed -i "s/REF .*/REF ${{ steps.dsqt.outputs.sha }}/" ports/dsqt/portfile.cmake
+
+    - name: Bump version in vcpkg.json
+      shell: bash
+      run: |
+        VERSION=$(curl -s https://raw.githubusercontent.com/Unispace365/DsQt/main/Library/VERSION.txt | tr -d '[:space:]')
+        jq --arg v "$VERSION" '.version = $v | del(."port-version")' \
+          ports/dsqt/vcpkg.json > tmp.json && mv tmp.json ports/dsqt/vcpkg.json
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+        vcpkgGitCommitId: '4b77da7fed37817f124936239197833469f1b9a8'
+
+    - name: Commit port changes
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add ports/dsqt/
+        git commit -m "Update dsqt port to ${{ steps.dsqt.outputs.sha }}"
+
+    - name: Run x-add-version
+      shell: cmd
+      run: >
+        vcpkg --x-builtin-ports-root=./ports
+        --x-builtin-registry-versions-dir=./versions
+        x-add-version --all --overwrite-version
+
+    - name: Commit and push version data
+      shell: bash
+      run: |
+        git add versions/
+        git commit -m "Update version data for dsqt"
+        git push

--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -23,13 +23,18 @@ jobs:
       id: dsqt
       shell: bash
       run: |
-        BASE_VERSION=$(curl -s https://raw.githubusercontent.com/Unispace365/DsQt/main/Library/VERSION.txt | tr -d '[:space:]')
+        set -euo pipefail
         if [ "${{ github.event_name }}" = "workflow_run" ]; then
+          BASE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/Unispace365/DsQt/${{ github.event.workflow_run.head_sha }}/Library/VERSION.txt" | tr -d '[:space:]')
           VERSION="${BASE_VERSION}.${{ github.event.workflow_run.run_number }}"
         else
           # workflow_dispatch: derive from the latest library release tag
-          VERSION=$(curl -s "https://api.github.com/repos/Unispace365/DsQt/releases" \
-            | jq -r '[.[] | select(.tag_name | startswith("library/v"))] | first | .tag_name | ltrimstr("library/v")')
+          VERSION=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/Unispace365/DsQt/releases?per_page=100" \
+            | jq -r '[.[] | select(.draft == false and .prerelease == false) | select(.tag_name | startswith("library/v"))] | first | .tag_name | ltrimstr("library/v")')
+        fi
+        if [ -z "${VERSION:-}" ] || [ "$VERSION" = "null" ]; then
+          echo "Failed to resolve DsQt version" >&2
+          exit 1
         fi
         URL="https://github.com/Unispace365/DsQt/releases/download/library%2Fv${VERSION}/dsqt-${VERSION}.zip"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -30,12 +30,20 @@ jobs:
     - name: Update portfile REF
       shell: bash
       run: |
-        sed -i "s/REF .*/REF ${{ steps.dsqt.outputs.sha }}/" ports/dsqt/portfile.cmake
+        # Anchor match to lines starting with optional whitespace + REF (avoids matching HEAD_REF)
+        sed -i "s/^\( *\)REF .*/\1REF ${{ steps.dsqt.outputs.sha }}/" ports/dsqt/portfile.cmake
 
     - name: Bump version in vcpkg.json
       shell: bash
       run: |
-        VERSION=$(curl -s https://raw.githubusercontent.com/Unispace365/DsQt/main/Library/VERSION.txt | tr -d '[:space:]')
+        BASE_VERSION=$(curl -s https://raw.githubusercontent.com/Unispace365/DsQt/main/Library/VERSION.txt | tr -d '[:space:]')
+        if [ "${{ github.event_name }}" = "workflow_run" ]; then
+          VERSION="${BASE_VERSION}.${{ github.event.workflow_run.run_number }}"
+        else
+          # workflow_dispatch: derive from the latest library release tag
+          VERSION=$(curl -s "https://api.github.com/repos/Unispace365/DsQt/releases" \
+            | jq -r '[.[] | select(.tag_name | startswith("library/v"))] | first | .tag_name | ltrimstr("library/v")')
+        fi
         jq --arg v "$VERSION" '.version = $v | del(."port-version")' \
           ports/dsqt/vcpkg.json > tmp.json && mv tmp.json ports/dsqt/vcpkg.json
 
@@ -51,10 +59,10 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add ports/dsqt/
-        git commit -m "Update dsqt port to ${{ steps.dsqt.outputs.sha }}"
+        git diff --cached --quiet && echo "No port changes to commit" || git commit -m "Update dsqt port to ${{ steps.dsqt.outputs.sha }}"
 
     - name: Run x-add-version
-      shell: cmd
+      shell: bash
       run: >
         vcpkg --x-builtin-ports-root=./ports
         --x-builtin-registry-versions-dir=./versions
@@ -64,5 +72,5 @@ jobs:
       shell: bash
       run: |
         git add versions/
-        git commit -m "Update version data for dsqt"
+        git diff --cached --quiet && echo "No version data changes to commit" || git commit -m "Update version data for dsqt"
         git push

--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -69,7 +69,7 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add ports/dsqt/
-        git diff --cached --quiet && echo "No port changes to commit" || git commit -m "Update dsqt port to ${{ steps.dsqt.outputs.sha }}"
+        git diff --cached --quiet && echo "No port changes to commit" || git commit -m "Update dsqt port to v${{ steps.dsqt.outputs.version }}"
 
     - name: Run x-add-version
       shell: bash

--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-registry:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout vcpkg-registry
@@ -19,21 +19,8 @@ jobs:
         repository: Unispace365/vcpkg-registry
         token: ${{ secrets.REGISTRY_PAT }}
 
-    - name: Get new DsQt commit SHA
+    - name: Resolve version and zip URL
       id: dsqt
-      shell: bash
-      run: |
-        SHA=$(curl -s https://api.github.com/repos/Unispace365/DsQt/commits/main \
-          | jq -r '.sha')
-        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-
-    - name: Update portfile REF
-      shell: bash
-      run: |
-        # Anchor match to lines starting with optional whitespace + REF (avoids matching HEAD_REF)
-        sed -i "s/^\( *\)REF .*/\1REF ${{ steps.dsqt.outputs.sha }}/" ports/dsqt/portfile.cmake
-
-    - name: Bump version in vcpkg.json
       shell: bash
       run: |
         BASE_VERSION=$(curl -s https://raw.githubusercontent.com/Unispace365/DsQt/main/Library/VERSION.txt | tr -d '[:space:]')
@@ -44,7 +31,30 @@ jobs:
           VERSION=$(curl -s "https://api.github.com/repos/Unispace365/DsQt/releases" \
             | jq -r '[.[] | select(.tag_name | startswith("library/v"))] | first | .tag_name | ltrimstr("library/v")')
         fi
-        jq --arg v "$VERSION" '.version = $v | del(."port-version")' \
+        URL="https://github.com/Unispace365/DsQt/releases/download/library%2Fv${VERSION}/dsqt-${VERSION}.zip"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "url=$URL"         >> "$GITHUB_OUTPUT"
+        echo "filename=dsqt-${VERSION}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: Compute SHA512
+      id: sha
+      shell: bash
+      run: |
+        curl -fsSL "${{ steps.dsqt.outputs.url }}" -o dsqt-download.zip
+        SHA512=$(sha512sum dsqt-download.zip | awk '{print $1}')
+        echo "sha512=$SHA512" >> "$GITHUB_OUTPUT"
+
+    - name: Update portfile
+      shell: bash
+      run: |
+        sed -i "s|URLS \"https://github.com/Unispace365/DsQt/releases/download/.*\"|URLS \"${{ steps.dsqt.outputs.url }}\"|" ports/dsqt/portfile.cmake
+        sed -i "s|FILENAME \"dsqt-.*\.zip\"|FILENAME \"${{ steps.dsqt.outputs.filename }}\"|" ports/dsqt/portfile.cmake
+        sed -i "s|SHA512 [0-9a-f]*|SHA512 ${{ steps.sha.outputs.sha512 }}|" ports/dsqt/portfile.cmake
+
+    - name: Bump version in vcpkg.json
+      shell: bash
+      run: |
+        jq --arg v "${{ steps.dsqt.outputs.version }}" '.version = $v | del(."port-version")' \
           ports/dsqt/vcpkg.json > tmp.json && mv tmp.json ports/dsqt/vcpkg.json
 
     - name: Setup vcpkg

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -77,6 +77,8 @@ find_package(Qt6 6.9
         Quick
 )
 
+option(DSQT_BUNDLE_DEPENDENCIES "Bundle vcpkg dependencies (e.g. tomlplusplus) into the DsQt install" ON)
+
 option(DSQT_BUILD_TESTS "Build and run DsQt unit tests" OFF)
 if(DSQT_BUILD_TESTS)
     enable_testing()
@@ -325,7 +327,7 @@ if(PROJECT_IS_TOP_LEVEL)
     # prefix and installs a self-contained cmake config.  This makes DsQt fully
     # self-contained: consuming projects no longer need vcpkg or any extra
     # CMAKE_PREFIX_PATH entry to satisfy find_package(Dsqt).
-    if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    if(DSQT_BUNDLE_DEPENDENCIES AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
         set(_dsqt_toml_vcpkg "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}")
 
         # Headers (toml++ puts everything under include/toml++/)

--- a/Library/cmake/DsQtConfig.cmake.in
+++ b/Library/cmake/DsQtConfig.cmake.in
@@ -50,7 +50,7 @@ endif()
 # ----------------------------------------------------------------------
 # Compute installation paths (public variables for consumers)
 # ----------------------------------------------------------------------
-get_filename_component(DSQT_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(DSQT_INSTALL_PREFIX "${PACKAGE_PREFIX_DIR}")
 set(DSQT_LIB_DIR "${DSQT_INSTALL_PREFIX}/lib")
 set(DSQT_INCLUDE_DIR "${DSQT_INSTALL_PREFIX}/include")
 set(DSQT_BIN_DIR "${DSQT_INSTALL_PREFIX}/bin")


### PR DESCRIPTION
This adds a workflow that, after the Build Library workflow has ran successfully, gathers all the required version data and updates our "vcpkg-registry" repository to make the new version available via VCPKG.

To have DsQt as a dependency for your project, add a `vcpkg-configuration.json` file with the following contents:
```
{
  "registries": [
    {
      "kind": "git",
      "repository": "https://github.com/Unispace365/vcpkg-registry.git",
      "baseline": "70d78d80f3ed26f02af82a25e05fab4ccb5a9d82",
      "packages": ["dsqt"]
    }
  ],
  "default-registry": {
    "kind": "builtin",
    "baseline": "4b77da7fed37817f124936239197833469f1b9a8"
  }
}
```
This will tell VCPKG to use our server to find Dsqt.

If you want to use a more recent version of Dsqt, update the baseline to point to the latest SHA commit.

@afrancois : I can only properly test this if the workflow is on the `main` branch. I have done my best to test as much as I could using "act" on Docker and it seems to work, but we can only know that once this PR is approved.