### PR TITLE
Fix VS detection in build_and_install.bat for VS 2022/2026

### DIFF
--- a/Library/build_and_install.bat
+++ b/Library/build_and_install.bat
@@ -29,13 +29,8 @@ if defined PRINT_HELP (
 :script_start
 
 REM Set up the MSVC developer environment if not already active
-if not defined VSINSTALLDIR (
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-    if %errorlevel% neq 0 (
-        echo Failed to set up MSVC environment.
-        exit /b %errorlevel%
-    )
-)
+call :setup_msvc
+if errorlevel 1 exit /b 1
 
 set PRESET=ninja
 set RUN_TESTS=0
@@ -416,4 +411,36 @@ set /a M = %~1 / 60
 set /a S = %~1 %% 60
 set RESULT=%M%m %S%s
 endlocal & set %~2=%RESULT%
+goto :eof
+
+:: Initialize the MSVC x64 developer environment if not already active.
+:: Locates Visual Studio 2022 (v17) or 2026 (v18), any edition, via vswhere
+:: with a path-probe fallback. Also ensures Ninja (bundled with the VS C++
+:: CMake tools) is on PATH.
+:setup_msvc
+if defined VSINSTALLDIR goto :eof
+set "_VSINSTALL="
+set "_VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%_VSWHERE%" (
+    for /f "usebackq tokens=*" %%i in (`"%_VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "_VSINSTALL=%%i"
+)
+if not defined _VSINSTALL (
+    for %%V in (18 2026 2022 17) do for %%E in (Community Professional Enterprise BuildTools) do if not defined _VSINSTALL if exist "C:\Program Files\Microsoft Visual Studio\%%V\%%E\VC\Auxiliary\Build\vcvarsall.bat" set "_VSINSTALL=C:\Program Files\Microsoft Visual Studio\%%V\%%E"
+)
+if not defined _VSINSTALL (
+    powershell -NoProfile -Command "Write-Host 'ERROR: Could not find Visual Studio 2022 or 2026 with the C++ x64 toolset. Install the Desktop development with C++ workload.' -ForegroundColor Red"
+    exit /b 1
+)
+if not exist "%_VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" (
+    powershell -NoProfile -Command "Write-Host 'ERROR: vcvarsall.bat not found under %_VSINSTALL%.' -ForegroundColor Red"
+    exit /b 1
+)
+powershell -NoProfile -Command "Write-Host '    Visual Studio: %_VSINSTALL%' -ForegroundColor Yellow"
+call "%_VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" amd64
+if errorlevel 1 (
+    powershell -NoProfile -Command "Write-Host 'ERROR: Failed to initialize MSVC environment via vcvarsall.bat.' -ForegroundColor Red"
+    exit /b 1
+)
+REM Ensure Ninja (bundled with the VS C++ CMake tools) is on PATH.
+where ninja >nul 2>&1 || set "PATH=%_VSINSTALL%\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%PATH%"
 goto :eof


### PR DESCRIPTION
Replace the hardcoded VS 2022 vcvarsall.bat path with a :setup_msvc routine that locates Visual Studio 2022 (v17) or 2026 (v18), any edition, via vswhere with a path-probe fallback. Also fixes a delayed-expansion bug that silently ignored vcvarsall failures, and ensures Ninja (bundled with the VS C++ CMake tools) is on PATH.